### PR TITLE
pypyr v5 example

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -42,11 +42,11 @@
         },
         "pypyr": {
             "hashes": [
-                "sha256:304a895ee6f7b01a048bd35191b104b1ed4a7f51f63e61ca024d5d85e4650d91",
-                "sha256:c4f13ed516021344e67f6ab6cd7b1f17523165304a1a8b4c9cb5dc491771152e"
+                "sha256:48aad54c90c02ee441dfbb15bf24ba190ca982b83bba971edce5eac87d72aa1a",
+                "sha256:9f765f2bbdf4e95508e1d7c828726a55b5cfd02b0c8de3cf017272ef993c9d0a"
             ],
             "index": "pypi",
-            "version": "==4.5.0"
+            "version": "==5.0.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -58,19 +58,19 @@
         },
         "rich": {
             "hashes": [
-                "sha256:13ac80676e12cf528dc4228dc682c8402f82577c2aa67191e294350fa2c3c4e9",
-                "sha256:517b4e0efd064dd1fe821ca93dd3095d73380ceac1f0a07173d507d9b18f1396"
+                "sha256:8bfe4546d56b4131298d3a9e571a0742de342f1593770bd0d4707299f772a0af",
+                "sha256:ab9cbfd7a3802d8c6f0fa91e974630e2a69447972dcbb9dfe9b01016dd95e38e"
             ],
             "index": "pypi",
-            "version": "==10.7.0"
+            "version": "==10.14.0"
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:505d0c2d7d0ccc2b68eca0e23fb78a86504c2a7e95ec5f2ccb216557c380e152",
-                "sha256:b5e96c0a6619830a7733099f0599b56556a963c6114ef64d0ddb4673347b426f"
+                "sha256:9751de4cbb57d4bfbf8fc394e125ed4a2f170fbff3dc3d78abf50be85924f8be",
+                "sha256:9af3ec5d7f8065582f3aa841305465025d0afd26c5fb54e15b964e11838fc74f"
             ],
             "index": "pypi",
-            "version": "==0.17.11"
+            "version": "==0.17.17"
         },
         "ruamel.yaml.clib": {
             "hashes": [

--- a/pipelines/test-pipe.yaml
+++ b/pipelines/test-pipe.yaml
@@ -4,8 +4,9 @@ steps:
   - name: pypyr.steps.py
     comment: Print 'hi from python' from python
     in:
-      pycode: |
+      py: |
         print('hi from python')
+        assert not finished
   
   - name: pypyr.steps.py
     comment: Use python to sleep for 2 seconds
@@ -20,10 +21,10 @@ steps:
       cmd: 
         run: nmap.exe -T4 scanme.nmap.org
         save: True
-  - name: pypyr.steps.contextsetf
+  - name: pypyr.steps.set
     comment: Set some stuff in the context
     in:
-      contextSetf:
+      set:
         myoutput: I was set in the pipeline!
         some_nesting:
           down_level:
@@ -32,7 +33,7 @@ steps:
             arb_bool: False
 
 on_success:
-  - name: pypyr.steps.contextsetf
+  - name: pypyr.steps.set
     in:
-      contextSetf:
+      set:
         finished: True

--- a/piper/pypyr5asyncio.py
+++ b/piper/pypyr5asyncio.py
@@ -1,0 +1,58 @@
+import asyncio
+
+import logging
+
+from pypyr import pipelinerunner
+
+from rich.console import Console
+from rich.logging import RichHandler
+
+
+FORMAT = "%(message)s"
+logging.basicConfig(
+    level=25, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()]
+)
+console = Console()
+
+
+def run_pipeline(dict_in):
+    # this is blocking
+    # returns the context as it is after pipeline completes
+    # this context is unique to this specific pipeline run attempt
+    return pipelinerunner.run(pipeline_name='pipelines/test-pipe',
+                              dict_in=dict_in)
+
+
+async def main():
+    """async entrypoint"""
+    loop = asyncio.get_running_loop()
+
+    futures = []
+
+    # somewhat arbitrarily create 5X pypyr run instructions/futures
+    for i in range(5):
+        # initialize context with this:
+        dict_in = {'finished': False,
+                   'progress': 0,
+                   'arbkey': 'pipe',
+                   'anotherkey': 'song',
+                   'runid': i
+                   }
+
+        # this runs on the default loop's executor
+        # you maybe want to create a custom threadpool instead
+        futures.append(loop.run_in_executor(None, run_pipeline, dict_in))
+
+    # run the futures all concurrently
+    console.log("starting pipelines. . .")
+    results = await asyncio.gather(*futures)
+
+    # each result is the output context from each individual pipeline run
+    for result in results:
+        # printing for the giggles, but you can merge/update etc. here to
+        # do something useful instead
+        console.log(result)
+
+asyncio.run(main())
+
+console.log(':smiley: done')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colorama==0.4.4
 commonmark==0.9.1
 Pygments==2.10.0
-pypyr==4.5.0
+pypyr>=5
 python-dateutil==2.8.2
 rich==10.7.0
 ruamel.yaml==0.17.11


### PR DESCRIPTION
pypyr v5 has upgraded the main API entrypoint. (I'm the maintainer of the pypyr proj, is how I happen to know 😉 )

Although the original code in `__main__.py` looks like it is still in an experimental phase, if you did run that as is with pypyr >=v5 you'll get breakages.

So rather than leave you scratching your head with breaking code, I thought I'd add an example file `pypyr5asyncio.py` showing how to do what I _think_ (I might well be wrong! 😄 ) you're trying to achieve using just the public API _without_ having to delve into the internals like the experiments in `__main__` are doing.

In the name of using the shiny & new I used asyncio with ThreadPoolExecutor, rather than the lower level Thread itself. Each pipeline initialises its own distinct context with an input dict (this is how you get your args into your pipeline), and returns the resulting Context when it finishes processing.

As is hopefully obvious from the file-name, I by no means suggest that the example code I give here is production worthy, or even fit for purpose, it's just a rough & ready demo of how you could go about things if you wanted to run multiple pipelines concurrently and collate the resulting context from each at the end.

The very short summary of the "why" is: absolutely DO NOT share the Context() instance between different pipelines on different threads/coroutines. The context maintains state for pipeline-specific internal run-state data, so sharing is very much not caring here.

Release notes here https://pypyr.io/updates/releases/v5.0.0/.

Minor tweaks to the test pipeline:
- using the `py` input on `pypyr.steps.py` just to demonstrate using bare context keys as variable names
- not essential, but `pypyr.steps.set` is a new less-annoying-typing-necessary alias for `contextsetf` 

Hope this helps!